### PR TITLE
Synchronize local/RTD output locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 /docs/build/
+/docs/source/api
 /docs/source/generated
 
 # PyBuilder

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,11 +7,11 @@ all: apidoc
 
 apidoc: clean-apidoc
 	sphinx-apidoc --private --module-first --force \
-      --output-dir "$(SOURCEDIR)/generated" \
+      --output-dir "$(SOURCEDIR)/api" \
       ../src/pylegendgeom ../src/pylegendgeom/_version.py
 
 clean-apidoc:
-	rm -rf "$(SOURCEDIR)/generated"
+	rm -rf "$(SOURCEDIR)/api"
 
 clean: clean-apidoc
 	rm -rf "$(BUILDDIR)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,7 @@ intersphinx_mapping = {
     "scipy": ("http://docs.scipy.org/doc/scipy/reference", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
     "matplotlib": ("http://matplotlib.org/stable", None),
+    "pyg4ometry": ("https://pyg4ometry.readthedocs.io/en/latest", None),
 }  # add new intersphinx mappings here
 
 # sphinx-autodoc

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,4 +7,4 @@ Table of Contents
 .. toctree::
    :maxdepth: 1
 
-   Package API reference <generated/modules>
+   Package API reference <api/modules>


### PR DESCRIPTION
Makefile for docs used "generated" as output directory for module docs whilst RTD build used "api". Follow upstream LEGEND projects and unify on "api" as output dir.